### PR TITLE
Feature/baukasten support

### DIFF
--- a/src/api/argo.go
+++ b/src/api/argo.go
@@ -23,7 +23,7 @@ func UpdateArgoApplicationSet(c *model.Config, repo *git.Repository) {
 
 	wt := checkout(repo, "main", false)
 
-	filePath := fmt.Sprintf(ValuesLocation, wt.Filesystem.Root(), c.Env, c.ImageTagFilename)
+	filePath := fmt.Sprintf(ValuesLocation, wt.Filesystem.Root(), c.Env, c.AppConfigFile)
 	logger.Debug("Updating file: %s", filePath)
 	updateImageTag(c, filePath)
 
@@ -68,13 +68,13 @@ func protectEnvironments(c *model.Config) {
 func UpdateAllStages(c *model.Config, wt *git.Worktree, repo *git.Repository) {
 	logger.Info("Updating all stages to new image tag to prepare deployment")
 
-	values := ParseYaml(fmt.Sprintf(ValuesLocation, wt.Filesystem.Root(), "main", c.ImageTagFilename))
+	values := ParseYaml(fmt.Sprintf(ValuesLocation, wt.Filesystem.Root(), "main", c.AppConfigFile))
 	imagetagNode, err := FindNode(values.Content[0], c.TagLocation)
 	utils.CheckIfError(err)
 	c.ImageTag = imagetagNode.Value
 
 	for _, stage := range c.Stages {
-		filePath := fmt.Sprintf(ValuesLocation, wt.Filesystem.Root(), stage, c.ImageTagFilename)
+		filePath := fmt.Sprintf(ValuesLocation, wt.Filesystem.Root(), stage, c.AppConfigFile)
 		logger.Debug("Updating file: %s", filePath)
 		updateImageTag(c, filePath)
 	}

--- a/src/api/argo.go
+++ b/src/api/argo.go
@@ -23,7 +23,7 @@ func UpdateArgoApplicationSet(c *model.Config, repo *git.Repository) {
 
 	wt := checkout(repo, "main", false)
 
-	filePath := fmt.Sprintf(ValuesLocation, wt.Filesystem.Root(), c.Env)
+	filePath := fmt.Sprintf(ValuesLocation, wt.Filesystem.Root(), c.Env) // TODO muss für Baukasten angepasst werden
 	logger.Debug("Updating file: %s", filePath)
 	updateImageTag(c, filePath)
 
@@ -68,13 +68,13 @@ func protectEnvironments(c *model.Config) {
 func UpdateAllStages(c *model.Config, wt *git.Worktree, repo *git.Repository) {
 	logger.Info("Updating all stages to new image tag to prepare deployment")
 
-	values := ParseYaml(fmt.Sprintf(ValuesLocation, wt.Filesystem.Root(), "main"))
+	values := ParseYaml(fmt.Sprintf(ValuesLocation, wt.Filesystem.Root(), "main")) // TODO muss für Baukasten angepasst werden
 	imagetagNode, err := FindNode(values.Content[0], c.TagLocation)
 	utils.CheckIfError(err)
 	c.ImageTag = imagetagNode.Value
 
 	for _, stage := range c.Stages {
-		filePath := fmt.Sprintf(ValuesLocation, wt.Filesystem.Root(), stage)
+		filePath := fmt.Sprintf(ValuesLocation, wt.Filesystem.Root(), stage) // TODO muss für Baukasten angepasst werden
 		logger.Debug("Updating file: %s", filePath)
 		updateImageTag(c, filePath)
 	}

--- a/src/api/argo.go
+++ b/src/api/argo.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	ApplicationsetLocation = "%s/argocd/applicationset.yaml"
-	ValuesLocation         = "%s/apps/env/%s/values.yaml"
+	ValuesLocation         = "%s/apps/env/%s/%s"
 	TemplateLocation       = "%s/apps/env/%s"
 )
 
@@ -23,7 +23,7 @@ func UpdateArgoApplicationSet(c *model.Config, repo *git.Repository) {
 
 	wt := checkout(repo, "main", false)
 
-	filePath := fmt.Sprintf(ValuesLocation, wt.Filesystem.Root(), c.Env) // TODO muss für Baukasten angepasst werden
+	filePath := fmt.Sprintf(ValuesLocation, wt.Filesystem.Root(), c.Env, c.ImageTagFilename)
 	logger.Debug("Updating file: %s", filePath)
 	updateImageTag(c, filePath)
 
@@ -68,13 +68,13 @@ func protectEnvironments(c *model.Config) {
 func UpdateAllStages(c *model.Config, wt *git.Worktree, repo *git.Repository) {
 	logger.Info("Updating all stages to new image tag to prepare deployment")
 
-	values := ParseYaml(fmt.Sprintf(ValuesLocation, wt.Filesystem.Root(), "main")) // TODO muss für Baukasten angepasst werden
+	values := ParseYaml(fmt.Sprintf(ValuesLocation, wt.Filesystem.Root(), "main", c.ImageTagFilename))
 	imagetagNode, err := FindNode(values.Content[0], c.TagLocation)
 	utils.CheckIfError(err)
 	c.ImageTag = imagetagNode.Value
 
 	for _, stage := range c.Stages {
-		filePath := fmt.Sprintf(ValuesLocation, wt.Filesystem.Root(), stage) // TODO muss für Baukasten angepasst werden
+		filePath := fmt.Sprintf(ValuesLocation, wt.Filesystem.Root(), stage, c.ImageTagFilename)
 		logger.Debug("Updating file: %s", filePath)
 		updateImageTag(c, filePath)
 	}

--- a/src/api/argo_test.go
+++ b/src/api/argo_test.go
@@ -48,7 +48,7 @@ func executeUpdateAllStages(test updateAllStagesTest, t *testing.T) {
 	wt, _ := repo.Worktree()
 	// replace current tag of main stage with whatever 'unitTestTag' holds.
 	err = prepareMainStage(
-		fmt.Sprintf("%s/apps/env/main/%s", wt.Filesystem.Root(), config.ImageTagFilename),
+		fmt.Sprintf("%s/apps/env/main/%s", wt.Filesystem.Root(), config.AppConfigFile),
 		config.TagLocation)
 	if err != nil {
 		t.Fatal("failed to prepare test, ", err)
@@ -59,7 +59,7 @@ func executeUpdateAllStages(test updateAllStagesTest, t *testing.T) {
 
 	// VALIDATE
 	for _, stage := range stages[1:] {
-		stageToValidatePath := fmt.Sprintf("%s/apps/env/%s/%s", wt.Filesystem.Root(), stage, config.ImageTagFilename)
+		stageToValidatePath := fmt.Sprintf("%s/apps/env/%s/%s", wt.Filesystem.Root(), stage, config.AppConfigFile)
 		rootNode := ParseYaml(stageToValidatePath)
 		tagNode, err := FindNode(rootNode.Content[0], config.TagLocation)
 		if err != nil {
@@ -131,7 +131,7 @@ func getDefaultConfig() model.Config {
 		RepoToken:                 "",
 		InfraRepoSuffix:           "-ci",
 		ImageTag:                  "",
-		ImageTagFilename:          "values.yaml",
+		AppConfigFile:             "values.yaml",
 		Stages:                    stages,
 		FromBranch:                "main",
 		ToBranch:                  "",

--- a/src/api/argo_test.go
+++ b/src/api/argo_test.go
@@ -1,0 +1,144 @@
+package api
+
+import (
+	"fmt"
+	"gepaplexx/git-workflows/model"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"os"
+	"testing"
+)
+
+const unitTestTag = "unittest"
+
+var stages = []string{"main", "dev", "qa", "prod"}
+
+type updateAllStagesTest struct {
+	name, repo, imageTagLocation string
+}
+
+var updateAllStagesTests = []updateAllStagesTest{
+	{"demo-microservice", "git@github.com:gepaplexx-demos/demo-microservice", "image.tag"},
+}
+
+func TestUpdateAllStages(t *testing.T) {
+	for _, test := range updateAllStagesTests {
+		// extra function to use advantages of defer
+		executeUpdateAllStages(test, t)
+	}
+}
+
+// region HELPER
+func executeUpdateAllStages(test updateAllStagesTest, t *testing.T) {
+	// SETUP
+	config := setupConfig(test.repo)
+	config.TagLocation = test.imageTagLocation
+	testdir, err := os.MkdirTemp("", test.name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(testdir)
+
+	repo, err := cloneGitRepoPlainClone(config, testdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wt, _ := repo.Worktree()
+	// replace current tag of main stage with whatever 'unitTestTag' holds.
+	err = prepareMainStage(
+		fmt.Sprintf("%s/apps/env/main/%s", wt.Filesystem.Root(), config.ImageTagFilename),
+		config.TagLocation)
+	if err != nil {
+		t.Fatal("failed to prepare test, ", err)
+	}
+
+	// TEST
+	UpdateAllStages(&config, wt, repo)
+
+	// VALIDATE
+	for _, stage := range stages[1:] {
+		stageToValidatePath := fmt.Sprintf("%s/apps/env/%s/%s", wt.Filesystem.Root(), stage, config.ImageTagFilename)
+		rootNode := ParseYaml(stageToValidatePath)
+		tagNode, err := FindNode(rootNode.Content[0], config.TagLocation)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		if tagNode.Value != unitTestTag {
+			t.Fatalf("TAG '%s' did not match expected TAG '%s'", tagNode.Value, unitTestTag)
+		}
+	}
+}
+
+func prepareMainStage(imageTagFile string, imageTagLocation string) error {
+	rootNode := ParseYaml(imageTagFile)
+	node, err := FindNode(rootNode.Content[0], imageTagLocation)
+	if err != nil {
+		return err
+	}
+	node.Value = unitTestTag
+	WriteYaml(rootNode, imageTagFile)
+	return nil
+}
+
+func cloneGitRepoPlainClone(c model.Config, testdir string) (*git.Repository, error) {
+	auth, err := setupAuth(c.SshConfigDir)
+	if err != nil {
+		return nil, err
+	}
+
+	repo, err := git.PlainClone(testdir, false, &git.CloneOptions{
+		URL:  fmt.Sprintf("%s%s.git", c.GitUrl, c.InfraRepoSuffix),
+		Auth: auth,
+	})
+
+	return repo, nil
+}
+func setupAuth(sshConfigDir string) (transport.AuthMethod, error) {
+	privateKeyfile := fmt.Sprintf("%s/id_rsa", sshConfigDir)
+	_, err := os.Stat(privateKeyfile)
+	if err != nil {
+		return nil, err
+	}
+	publicKeys, err := ssh.NewPublicKeysFromFile("git", privateKeyfile, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return publicKeys, nil
+}
+
+func setupConfig(repo string) model.Config {
+	config := getDefaultConfig()
+	config.Development = true
+	config.GitUrl = repo
+	homedir, _ := os.UserHomeDir()
+	config.SshConfigDir = fmt.Sprintf("%s/.ssh", homedir) // TODO überlegen wie das generischer gelöst werden kann, soll auch mit GH-Action funktionieren
+	return config
+}
+func getDefaultConfig() model.Config {
+	return model.Config{
+		Development:               true,
+		BaseDir:                   "/mnt/out/",
+		Username:                  "argo-ci",
+		Email:                     "argo-ci@gepardec.com",
+		GitUrl:                    "",
+		Reponame:                  "",
+		Branch:                    "main",
+		SshConfigDir:              "/workflow/.ssh/",
+		RepoToken:                 "",
+		InfraRepoSuffix:           "-ci",
+		ImageTag:                  "",
+		ImageTagFilename:          "values.yaml",
+		Stages:                    stages,
+		FromBranch:                "main",
+		ToBranch:                  "",
+		CommitRef:                 "no reference supplied",
+		Force:                     false,
+		ResourcesOnly:             false,
+		Descriptor:                "workflow-descriptor.json",
+		DefaultDescriptorLocation: "/workflow/default-descriptor.json",
+	}
+}
+
+// endregion

--- a/src/api/argo_test.go
+++ b/src/api/argo_test.go
@@ -20,6 +20,7 @@ type updateAllStagesTest struct {
 
 var updateAllStagesTests = []updateAllStagesTest{
 	{"demo-microservice", "git@github.com:gepaplexx-demos/demo-microservice", "image.tag"},
+	// TODO add test for baukastensystem (needs repo where the baukasten is used)
 }
 
 func TestUpdateAllStages(t *testing.T) {
@@ -94,6 +95,7 @@ func cloneGitRepoPlainClone(c model.Config, testdir string) (*git.Repository, er
 
 	return repo, nil
 }
+
 func setupAuth(sshConfigDir string) (transport.AuthMethod, error) {
 	privateKeyfile := fmt.Sprintf("%s/id_rsa", sshConfigDir)
 	_, err := os.Stat(privateKeyfile)

--- a/src/api/yaml.go
+++ b/src/api/yaml.go
@@ -134,9 +134,8 @@ func handleMappingNode(node *yaml.Node, lookingFor model.YamlPath, current *stri
 			filteredNode, err := filter(node.Content[i+1].Content, currentFilter)
 			if err != nil {
 				return nil
-			} else {
-				node = filteredNode
 			}
+			node = filteredNode
 		}
 		if *current == lookingFor.YamlPath() {
 			return node.Content[i+1]

--- a/src/api/yaml.go
+++ b/src/api/yaml.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"gepaplexx/git-workflows/logger"
+	"gepaplexx/git-workflows/model"
 	"gepaplexx/git-workflows/utils"
 	"gopkg.in/yaml.v3"
 	"io"
@@ -96,11 +97,12 @@ func NewEnvNode(env, branch string) *yaml.Node {
 }
 
 func FindNode(rootNode *yaml.Node, lookingFor string) (*yaml.Node, error) {
+	lookingForPath := model.ParseYamlPath(lookingFor)
 	current := ""
-	return find(rootNode, lookingFor, &current)
+	return find(rootNode, lookingForPath, &current)
 }
 
-func find(node *yaml.Node, lookingFor string, current *string) (*yaml.Node, error) {
+func find(node *yaml.Node, lookingFor model.YamlPath, current *string) (*yaml.Node, error) {
 	switch node.Kind {
 	case yaml.MappingNode:
 		{
@@ -116,7 +118,7 @@ func find(node *yaml.Node, lookingFor string, current *string) (*yaml.Node, erro
 		}
 	case yaml.ScalarNode:
 		{
-			if node.Value == lookingFor {
+			if node.Value == lookingFor.YamlPath() {
 				return node, nil
 			}
 		}
@@ -124,10 +126,19 @@ func find(node *yaml.Node, lookingFor string, current *string) (*yaml.Node, erro
 	return nil, errors.New("element not found")
 }
 
-func handleMappingNode(node *yaml.Node, lookingFor string, current *string) *yaml.Node {
+func handleMappingNode(node *yaml.Node, lookingFor model.YamlPath, current *string) *yaml.Node {
 	for i := 0; i < len(node.Content)-1; i += 2 {
 		appendIfValid(current, node.Content[i].Value, lookingFor)
-		if *current == lookingFor {
+		currentFilter := lookingFor.FilterFor(node.Content[i].Value)
+		if (currentFilter != model.Filter{}) {
+			filteredNode, err := filter(node.Content[i+1].Content, currentFilter)
+			if err != nil {
+				return nil
+			} else {
+				node = filteredNode
+			}
+		}
+		if *current == lookingFor.YamlPath() {
 			return node.Content[i+1]
 		}
 		found, err := find(node.Content[i+1], lookingFor, current)
@@ -139,7 +150,7 @@ func handleMappingNode(node *yaml.Node, lookingFor string, current *string) *yam
 	return nil
 }
 
-func handleSequenceNode(node *yaml.Node, lookingFor string, current *string) *yaml.Node {
+func handleSequenceNode(node *yaml.Node, lookingFor model.YamlPath, current *string) *yaml.Node {
 	for _, n := range node.Content {
 		found, err := find(n, lookingFor, current)
 		if err == nil {
@@ -149,14 +160,25 @@ func handleSequenceNode(node *yaml.Node, lookingFor string, current *string) *ya
 	return nil
 }
 
-func appendIfValid(current *string, appendix string, lookingFor string) {
+func filter(nodes []*yaml.Node, filter model.Filter) (*yaml.Node, error) {
+	for _, node := range nodes {
+		found := filter.Search(node.Content)
+		if found {
+			return node, nil
+		}
+	}
+
+	return nil, errors.New(fmt.Sprintf("no node with filter {key: %s, value: %s} found.", filter.Key, filter.Value))
+}
+
+func appendIfValid(current *string, appendix string, lookingFor model.YamlPath) {
 	newCurrent := *current
 	if *current != "" {
 		newCurrent += "."
 	}
 
 	newCurrent += appendix
-	if !strings.HasPrefix(lookingFor, newCurrent) {
+	if !strings.HasPrefix(lookingFor.YamlPath(), newCurrent) {
 		if *current != "" {
 			newCurrent = strings.TrimSuffix(newCurrent, "."+appendix)
 		} else {

--- a/src/api/yaml_test.go
+++ b/src/api/yaml_test.go
@@ -29,6 +29,40 @@ ports:
     protocol: TCP
 `
 
+var inputYamlBaukastenV1 = `apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: demo-microservice
+spec:
+  components:
+    - name: demo-microservice
+      type: deployment
+      properties:
+        image: "ghcr.io/gepaplexx/demo-microservice"
+        tag: "d821097"
+        ports:
+          - port: 8080
+            expose: true
+`
+
+var inputYamlBaukastenV2 = `apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: demo-microservice
+spec:
+  components:
+    - name: mega-backend
+      type: deployment
+      properties:
+        image: "ghcr.io/gepaplexx/mega-backend"
+        tag: "d821097"
+    - name: mega-frontend
+      type: deployment
+      properties:
+        image: "ghcr.io/gepaplexx/mega-frontend"
+        tag: "1234567"
+`
+
 var applicationSetYaml = `apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
@@ -171,6 +205,8 @@ var findNodeTests = []findNodeTest{
 	{inputYamlV1, "413b395", "demo-microservice.image.tag"},
 	{inputYamlV2, "413b395", "image.tag"},
 	{inputYamlV2, "8080", "ports.containerPort"},
+	{inputYamlBaukastenV2, "1234567", "spec.components[name=mega-frontend].properties.tag"},
+	{inputYamlBaukastenV2, "d821097", "spec.components[name=mega-backend].properties.tag"},
 }
 
 func TestFindNode(t *testing.T) {

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -48,6 +48,7 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&Config.InfraRepoSuffix, "infra-repo-suffix", "-ci", "Suffix for infrastructure git repository")
 	rootCmd.PersistentFlags().StringVar(&Config.ImageTag, "tag", "", "Commit-Hash/Image-Tag for the deployment change")
+	rootCmd.PersistentFlags().StringVar(&Config.ImageTagFilename, "image-tag-file-name", "values.yaml", "Name of the file in which the image tag can be found")
 	rootCmd.PersistentFlags().StringVar(&Config.TagLocation, "image-tag-location", "image.tag", "Location of image-tag in the infrastructure repository")
 	rootCmd.PersistentFlags().StringSliceVar(&Config.Stages, "stages", []string{"main", "dev", "qa", "prod"}, "deployment stages")
 	rootCmd.PersistentFlags().StringVar(&Config.FromBranch, "from-branch", "main", "Base branch for argo-create | Branch from which to deploy from")

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -48,7 +48,7 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&Config.InfraRepoSuffix, "infra-repo-suffix", "-ci", "Suffix for infrastructure git repository")
 	rootCmd.PersistentFlags().StringVar(&Config.ImageTag, "tag", "", "Commit-Hash/Image-Tag for the deployment change")
-	rootCmd.PersistentFlags().StringVar(&Config.ImageTagFilename, "image-tag-file-name", "values.yaml", "Name of the file in which the image tag can be found")
+	rootCmd.PersistentFlags().StringVar(&Config.AppConfigFile, "app-config-file", "values.yaml", "Name of the file in which the image tag can be found")
 	rootCmd.PersistentFlags().StringVar(&Config.TagLocation, "image-tag-location", "image.tag", "Location of image-tag in the infrastructure repository")
 	rootCmd.PersistentFlags().StringSliceVar(&Config.Stages, "stages", []string{"main", "dev", "qa", "prod"}, "deployment stages")
 	rootCmd.PersistentFlags().StringVar(&Config.FromBranch, "from-branch", "main", "Base branch for argo-create | Branch from which to deploy from")

--- a/src/model/config.go
+++ b/src/model/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	RepoToken                 string   `json:"repo_token"`
 	InfraRepoSuffix           string   `json:"infra_repo_suffix"`
 	ImageTag                  string   `json:"image_tag"`
+	ImageTagFilename          string   `json:"image_tag_file_name"`
 	TagLocation               string   `json:"tag_location"`
 	Stages                    []string `json:"stages"`
 	Env                       string   `json:"env"`

--- a/src/model/config.go
+++ b/src/model/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	RepoToken                 string   `json:"repo_token"`
 	InfraRepoSuffix           string   `json:"infra_repo_suffix"`
 	ImageTag                  string   `json:"image_tag"`
-	ImageTagFilename          string   `json:"image_tag_file_name"`
+	AppConfigFile             string   `json:"image_tag_file_name"`
 	TagLocation               string   `json:"tag_location"`
 	Stages                    []string `json:"stages"`
 	Env                       string   `json:"env"`

--- a/src/model/yamlPath.go
+++ b/src/model/yamlPath.go
@@ -1,0 +1,73 @@
+package model
+
+import (
+	"gopkg.in/yaml.v3"
+	"strings"
+)
+
+type Filter struct {
+	Key   string
+	Value string
+}
+type Element struct {
+	Name   string
+	Filter Filter
+}
+
+type YamlPath []Element
+
+func (p YamlPath) YamlPath() string {
+	if len(p) == 0 {
+		return ""
+	}
+
+	res := p[0].Name
+	for i := 1; i < len(p); i++ {
+		res += "." + p[i].Name
+	}
+
+	return res
+}
+
+func (p YamlPath) FilterFor(tag string) Filter {
+	for _, elem := range p {
+		if elem.Name == tag {
+			return elem.Filter
+		}
+	}
+
+	return Filter{}
+}
+
+func (f Filter) Search(nodes []*yaml.Node) bool {
+	for i := 0; i < len(nodes); i += 2 {
+		if nodes[i].Value == f.Key && nodes[i+1].Value == f.Value {
+			return true
+		}
+	}
+
+	return false
+}
+
+func ParseYamlPath(val string) YamlPath {
+	var res YamlPath
+	splitted := strings.Split(val, ".")
+	for _, s := range splitted {
+		if strings.Contains(s, "[") {
+			elem, filterVal, _ := strings.Cut(s, "[")
+			filterVal = strings.TrimSuffix(filterVal, "]")
+			keyVal := strings.Split(filterVal, "=")
+			res = append(res, Element{
+				Name: elem,
+				Filter: Filter{
+					Key:   keyVal[0],
+					Value: keyVal[1],
+				},
+			})
+		} else {
+			res = append(res, Element{Name: s})
+		}
+	}
+
+	return res
+}


### PR DESCRIPTION
Bei der TagLocation können jetzt Filter angegeben werden, zBsp.: spec.components[name=mega-frontend].properties.tag => hier wird bei mehreren Komponenten die richtige herausgesucht. Das ist notwendig damit die git-workflows auch fürs Baukastensystem funktionieren. An der ursprünglichen Logik hat sich nichts verändert, image.tag funktioniert zum Beispiel noch genauso wie davor.