### PR TITLE
Feature/baukasten support imagetag

### DIFF
--- a/src/api/argo.go
+++ b/src/api/argo.go
@@ -69,7 +69,7 @@ func UpdateAllStages(c *model.Config, wt *git.Worktree, repo *git.Repository) {
 	logger.Info("Updating all stages to new image tag to prepare deployment")
 
 	values := ParseYaml(fmt.Sprintf(ValuesLocation, wt.Filesystem.Root(), "main", c.AppConfigFile))
-	imagetagNode, err := FindNode(values.Content[0], c.TagLocation)
+	imagetagNode, err := FindNode(values.Content[0], c.GetTagLocation())
 	utils.CheckIfError(err)
 	c.ImageTag = imagetagNode.Value
 
@@ -83,7 +83,7 @@ func UpdateAllStages(c *model.Config, wt *git.Worktree, repo *git.Repository) {
 
 func updateImageTag(c *model.Config, filepath string) {
 	nodes := ParseYaml(filepath)
-	tagNode, err := FindNode(nodes.Content[0], c.TagLocation)
+	tagNode, err := FindNode(nodes.Content[0], c.GetTagLocation())
 	utils.CheckIfError(err)
 	tagNode.Value = c.ImageTag
 	WriteYaml(nodes, filepath)

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -50,6 +50,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&Config.ImageTag, "tag", "", "Commit-Hash/Image-Tag for the deployment change")
 	rootCmd.PersistentFlags().StringVar(&Config.AppConfigFile, "app-config-file", "values.yaml", "Name of the file in which the image tag can be found")
 	rootCmd.PersistentFlags().StringVar(&Config.TagLocation, "image-tag-location", "image.tag", "Location of image-tag in the infrastructure repository")
+	rootCmd.PersistentFlags().StringVar(&Config.TagLocation, "component", "", "OPTIONAL: for baukasten only. Specifies the component to update inside the application yaml.")
 	rootCmd.PersistentFlags().StringSliceVar(&Config.Stages, "stages", []string{"main", "dev", "qa", "prod"}, "deployment stages")
 	rootCmd.PersistentFlags().StringVar(&Config.FromBranch, "from-branch", "main", "Base branch for argo-create | Branch from which to deploy from")
 	rootCmd.PersistentFlags().StringVar(&Config.ToBranch, "to-branch", "", "Target branch for deployments")

--- a/src/model/config.go
+++ b/src/model/config.go
@@ -1,10 +1,15 @@
 package model
 
 import (
+	"bufio"
 	"fmt"
+	"os"
 )
 
-const baukastenTagLocationPattern = "spec.components[name=%s].properties.tag"
+const (
+	baukastenTagLocationPattern = "spec.components[name=%s].properties.tag"
+	valuesLocation              = "%s/apps/env/%s/%s"
+)
 
 type Config struct {
 	Development               bool     `json:"development"`
@@ -51,4 +56,30 @@ func (c *Config) GetTagLocation() string {
 	}
 
 	return fmt.Sprintf(baukastenTagLocationPattern, c.Component)
+}
+
+func (c *Config) BuildAppConfigFilePath(rootPath string, env string) (string, error) {
+	if c.Component == "" {
+		return fmt.Sprintf(valuesLocation, rootPath, env, c.AppConfigFile), nil
+	}
+
+	baukastenIndicatorFile := fmt.Sprintf(valuesLocation, rootPath, env, ".baukasten")
+	appConfigFileBK, err := readFirstLine(baukastenIndicatorFile)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf(valuesLocation, rootPath, env, appConfigFileBK), nil
+}
+
+func readFirstLine(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Scan()
+	return scanner.Text(), nil
 }

--- a/src/model/config.go
+++ b/src/model/config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 )
 
+const baukastenTagLocationPattern = "spec.components[name=%s].properties.tag"
+
 type Config struct {
 	Development               bool     `json:"development"`
 	BaseDir                   string   `json:"base_dir"`
@@ -27,6 +29,7 @@ type Config struct {
 	Descriptor                string   `json:"descriptor"`
 	DefaultDescriptorLocation string   `json:"default_descriptor_location"`
 	CommitRef                 string   `json:"commit_ref"`
+	Component                 string   `json:"component"`
 }
 
 func (c *Config) ApplicationClonePath() string {
@@ -40,4 +43,12 @@ func (c *Config) InfrastructureClonePath() string {
 
 func (c *Config) IsPushEnabled() bool {
 	return !c.Development
+}
+
+func (c *Config) GetTagLocation() string {
+	if c.Component == "" {
+		return c.TagLocation
+	}
+
+	return fmt.Sprintf(baukastenTagLocationPattern, c.Component)
 }

--- a/src/model/config_test.go
+++ b/src/model/config_test.go
@@ -1,0 +1,32 @@
+package model
+
+import "testing"
+
+type getTagLocationTest struct {
+	tagLocation, component, expected string
+}
+
+var getTagLocationTests = []getTagLocationTest{
+	{"image.tag", "", "image.tag"},
+	{"", "mega-backend", "spec.components[name=mega-backend].properties.tag"},
+	{"image.tag", "mega-backend", "spec.components[name=mega-backend].properties.tag"},
+}
+
+func TestConfig_GetTagLocation(t *testing.T) {
+	for _, test := range getTagLocationTests {
+		currentConfig := setupConfig(test)
+		if currentConfig.GetTagLocation() != test.expected {
+			t.Fatalf("expected value '%s' did not match '%s'", test.expected, currentConfig.GetTagLocation())
+		}
+	}
+}
+
+func setupConfig(test getTagLocationTest) Config {
+	var conf = Config{}
+	if test.tagLocation != "" {
+		conf.TagLocation = test.tagLocation
+	}
+
+	conf.Component = test.component
+	return conf
+}


### PR DESCRIPTION
Erster Entwurf damit git-workflows mit dem Baukastensystem umgehen kann. Bei gesetztem Parameter "component" wird die Baukastenvariante aktiviert (image tag wird nicht im values.yaml gesucht, taglocation wird fürs Baukastensystem angepasst). TODO: Argo Workflows um optional Parameter "component" erweitern.